### PR TITLE
Editorial edits

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,31 +1,25 @@
 ---
-# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after #.
+# Translation info https://www.w3.org/wiki/WAI/Website/Translate
 
-title: "How to Make Your Presentations Accessible to All"   # Do not translate "title:". Do translate the text after "title:".
-nav_title: "Make Presentations Accessible"   # A short title that is used in the navigation
+title: "How to Make Your Presentations Accessible to All"
+nav_title: "Make Presentations Accessible"
 
-lang: en   # Change "en" to the translated language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-last_updated: 2019-05-30   # Put the date of this translation YYYY-MM-DD (with month in the middle)
-# translators: #Add one -name: line for every translator
-# - name: "Translator Name Here"
-# contributors: #Add one -name: line for every contributor
-# - name: "Contributor Name Here"
-permalink: /teach-advocate/accessible-presentations/   # Add the language shortcode to the end; for example /teach-advocate/accessible-presentations/fr
-ref: /teach-advocate/accessible-presentations/   # Do not change this
-layout: default
+lang: en
+last_updated: 2019-05-30
+permalink: /teach-advocate/accessible-presentations/
+
 github:
   repository: w3c/wai-presentations2all
-  path: index.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: index.md
 
-footer: >   # Translate all the words below, including "Date:" and "Editor:". Do not change these dates.
+ref: /teach-advocate/accessible-presentations/
+footer: >
   <p><strong>Date:</strong> Updated 24 May 2018. First published May 2010.</p>
   <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. Contributors: <a href="http://www.w3.org/People/shadi/">Shadi Abou-Zahra</a> and <a href="https://www.w3.org/WAI/EO/EOWG-members">EOWG Participants</a>.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Developed with staff of the <a href="http://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> funded by the European Commission under the 6th Framework.</p>
 
 # Read Important Translations Guidance at https://www.w3.org/WAI/about/translating/#important
 # Read Translations Notes for this resource at https://github.com/w3c/wai-presentations2all/blob/master/README.md
-# end of translation instructions
-
 ---
 
 {::nomarkdown}

--- a/index.md
+++ b/index.md
@@ -55,9 +55,7 @@ Make your presentations, talks, meetings, and trainings accessible to everyone i
 
 {% include_cached excol.html type="all" %}
 
-{% include_cached excol.html type="start" id="basic" %}
-## Basics (for organizers & speakers)
-{% include_cached excol.html type="middle" %}
+## Basics (for organizers & speakers) {#basic}
 
 Be open to diversity in your audience and any accessibility issues. Basically, be aware that some of your audience might not be able to:
 
@@ -74,8 +72,6 @@ Organizers and speakers should do things like: ensure the facility is accessible
 Often speakers won't know if participants have disabilities. For example, at a large conference where organizers didn't ask registrants. In some cases, you might know the accessibility needs of participants ahead of time. Even then something could change. For example, a new participant could join the training at the last minute. Or someone could develop accessibility needs before the training.
 
 Make your event and your presentations fully accessible to prepare for any situation. 
-
-{% include_cached excol.html type="end" %}
 
 {% include_cached excol.html type="start" id="benefits" %}
 ## Benefits (organizers & speakers)

--- a/index.md
+++ b/index.md
@@ -28,14 +28,13 @@ footer: >   # Translate all the words below, including "Date:" and "Editor:". Do
 
 ---
 
-**Do you remember a time when people around you broke out in laughter, but you didn't hear the joke? <br>
-Be careful not to leave out information for some people in your audience. For example, if you say "you can read it on the slide", you are probably excluding people who cannot see the slide.**
-
 {::nomarkdown}
 {% include box.html type="start" h="2" title="Summary" class="full" %}
 {:/}
 
-This page helps you make your presentations, talks, meetings, and training accessible to all of your potential audience, including people with disabilities and others. Inclusive presentations have <a href="#benefits">many benefits</a>.
+When you ask people to “read the source on the slide”, you probably exclude people who cannot see the slides. If you show a video without captions, hard of hearing people and people speaking other languages might be unable to follow.
+
+Make your presentations, talks, meetings, and trainings accessible to everyone in your potential audience, including people with disabilities.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: "How to Make Your Presentations Accessible to All"   # Do not translate "
 nav_title: "Make Presentations Accessible"   # A short title that is used in the navigation
 
 lang: en   # Change "en" to the translated language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-last_updated: 2020-11-11   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+last_updated: 2019-05-30   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 # translators: #Add one -name: line for every translator
 # - name: "Translator Name Here"
 # contributors: #Add one -name: line for every contributor
@@ -65,13 +65,16 @@ Be open to diversity in your audience and any accessibility issues. Basically, b
 -  **speak** well or at all, or
 -  **understand** information presented in some ways well or at all.
 
-Organizers and speakers should do things like: ensure the facility is accessible, speak clearly into the microphone, describe pertinent visuals, and other considerations listed on this page.
+Organizers and speakers should:
+
+- ensure the facility is accessible, 
+- speak clearly, and into the microphone, 
+- describe relevant visuals, 
+- and other considerations listed on this page.
 
 **Respect participant's needs** and be open for other accessibility issues. People might have accessibility needs that you didn't think of. For example: Someone might need to take breaks at set times for insulin injections. Someone with Tourette syndrome might randomly shout out during a session. Someone with a physical disability who cannot take notes might need to record the session.
 
 Often speakers won't know if participants have disabilities. For example, at a large conference where organizers didn't ask registrants. In some cases, you might know the accessibility needs of participants ahead of time. Even then something could change. For example, a new participant could join the training at the last minute. Or someone could develop accessibility needs before the training.
-
-Make your event and your presentations fully accessible to prepare for any situation. 
 
 {% include_cached excol.html type="start" id="benefits" %}
 ## Benefits (organizers & speakers)
@@ -255,9 +258,10 @@ Information on web accessibility:
 
 
 {% include_cached excol.html type="end" %}
-{% include_cached excol.html type="start" id="terms" %}
-## Terminology (appendix)
-{% include_cached excol.html type="middle" %}
+
+{::nomarkdown}
+{% include box.html type="start" title="Terminology" h="2" class="" id="terms" %}
+{:/}
 
 <span id="at">assistive technology</span>
 :  Assistive technologies are software or equipment that people with disabilities use to improve interaction with the web, such as
@@ -272,4 +276,6 @@ Information on web accessibility:
 <span id="terps">interpreters</span>
 :  This includes sign language interpreters, cued speech transliterators, and others. Note that sign languages are different from spoken languages and there is not a one-to-one translation.
 
-{% include_cached excol.html type="end" %}
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}


### PR DESCRIPTION
- Integrate anecdote into the summary

- Remove expand/collapse from first section (that allows users to immediately read without further interaction on the site)

- Clarify content:

  - Set last-updated date

  - Formulate sentence to list

  - Remove broad “Make your event and your presentations fully accessible to prepare for any situation.” because I think “fully accessible” is maybe impossible, so is to “prepare for any situation”.

  - Put the terminology section into a box to remove it from the TOC and have a different presentation compared to the actual content of the page.