### PR TITLE
material ahead of time - screen sharing

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -166,9 +166,9 @@ For example, provide [captions](#captions){:.termref} _(called “intralingual s
 ## Planning Your Session (speakers)
 {% include_cached excol.html type="middle" %}
 
-### Provide material ahead of time, if requested _(in-person, remote)_
+### Provide material ahead of time _(in-person, remote)_
 
-Provide slides, handouts, and other material to participants, [interpreters](#terps){:.termref}, and [captioners](#captions){:.termref}, as needed. Make it accessible. (More about [providing accessible material](#material) is above.)
+Provide slides, handouts, and other material to participants, [interpreters](#terps){:.termref}, and [captioners](#captions){:.termref}, as needed. Make it accessible. (More about [providing accessible material](#material) is above.)<br>For remote sessions, note that content in screen sharing is not accessible. You will need to provide the accessible material to participants directly as needed.
 
 ### Work with [interpreters](#terps){:.termref} and [captioners](#captions){:.termref} _(in-person, remote)_
 

--- a/content/index.md
+++ b/content/index.md
@@ -168,7 +168,7 @@ For example, provide [captions](#captions){:.termref} _(called “intralingual s
 
 ### Provide material ahead of time _(in-person, remote)_
 
-Provide slides, handouts, and other material to participants, [interpreters](#terps){:.termref}, and [captioners](#captions){:.termref}, as needed. Make it accessible. (More about [providing accessible material](#material) is above.)<br>For remote sessions, note that content in screen sharing is not accessible. You will need to provide the accessible material to participants directly as needed.
+Provide slides, handouts, and other material to participants, [interpreters](#terps){:.termref}, and [captioners](#captions){:.termref}, as needed. Make it accessible. (More about [providing accessible material](#material) is above.)<br>For remote sessions, note that content in screen sharing is not accessible. You will need to provide the accessible material to participants who need it.
 
 ### Work with [interpreters](#terps){:.termref} and [captioners](#captions){:.termref} _(in-person, remote)_
 


### PR DESCRIPTION
For EOWG Review: _**update:** draft not updated with wording tweaked below in EOWG telecon_ <s>[draft pull request](https://deploy-preview-75--wai-presentations2all.netlify.app/teach-advocate/accessible-presentations/#planning-your-session-speakers)</s>, under "Planning Your Session" section, added remote screen sharing info:

> ### Provide material ahead of time _(in-person, remote)_
> Provide slides, handouts, and other material to participants, [interpreters](#terps), and [captioners](#captions), as needed. Make it accessible. (More about [providing accessible material](#material) is above.)<br>For remote sessions, note that content in screen sharing may not be accessible. You will often need to provide the accessible material to participants who need it.